### PR TITLE
Adding repository instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ For emacs24 themes
 M-x package-install load-theme-buffer-local
 ```
 
+If the above doesn't work, you may need to [configure your Emacs to
+use the Marmalade repository](http://marmalade-repo.org/) and try
+again.
+
+
 ## Using themes made for color-theme.el
 
 Interactively


### PR DESCRIPTION
This issue tripped me up at first. Apparently the default install of Emacs on OSX only points at the GNU repository, and it took a little Googling before I found these packages in the Marmalade repo.
