### PR TITLE
Broken load-theme-buffer-local #5

### DIFF
--- a/load-theme-buffer-local.el
+++ b/load-theme-buffer-local.el
@@ -29,7 +29,7 @@
 ;;;
 ;;; (add-hook 'java-mode-hook (lambda nil
 ;;;   (load-theme-buffer-local 'misterioso (current-buffer))))
-
+(require 'noflet)
 
 (defun custom-theme-buffer-local-spec-attrs (spec)
   (let* ((spec (face-spec-choose spec))
@@ -94,7 +94,7 @@
                   (mapcar 'symbol-name (custom-available-themes))))
          (read-buffer "on Buffer: " (current-buffer) t)))
   (or buffer (setq buffer (current-buffer)))
-  (flet ((custom-theme-recalc-face
+  (noflet ((custom-theme-recalc-face
           (symbol) (custom-theme-buffer-local-recalc-face symbol buffer))
          (custom-theme-recalc-variable
           (symbol) (custom-theme-buffer-local-recalc-variable symbol buffer)))


### PR DESCRIPTION
use 'noflet' instead of 'flet' to override
the functions 'custom-theme-buffer-local-recalc-face' and
'custom-theme-buffer-local-recalc-variable'.  In later versions
of emacs, 'flet' is reverting to lexical binding instead of
dynamic binding, thus the methods are no longer being hooked
downsteam.

This introduces a dependency on package 'noflet'.  I did not
update the autoload to automatically require this package.

Without this fix, on certain versions of emacs you will get
the following message when trying to run 'load-theme-buffer-local':

Symbol's function definition is void: symbol
